### PR TITLE
[Beta] fix(SandpackConsole): avoid unsubscribing the logs listeners

### DIFF
--- a/beta/src/components/MDX/Sandpack/Console.tsx
+++ b/beta/src/components/MDX/Sandpack/Console.tsx
@@ -87,7 +87,7 @@ type ConsoleData = Array<{
 
 const MAX_MESSAGE_COUNT = 100;
 
-export const SandpackConsole = () => {
+export const SandpackConsole = ({visible}: {visible: boolean}) => {
   const {listen} = useSandpack();
   const [logs, setLogs] = React.useState<ConsoleData>([]);
   const wrapperRef = React.useRef<HTMLDivElement>(null);
@@ -136,7 +136,7 @@ export const SandpackConsole = () => {
     }
   }, [logs]);
 
-  if (logs.length === 0) {
+  if (!visible || logs.length === 0) {
     return null;
   }
 

--- a/beta/src/components/MDX/Sandpack/Preview.tsx
+++ b/beta/src/components/MDX/Sandpack/Preview.tsx
@@ -222,7 +222,7 @@ export function Preview({
           loading={!isReady && iframeComputedHeight === null}
         />
       </div>
-      {!error && <SandpackConsole />}
+      <SandpackConsole visible={!error} />
     </SandpackStack>
   );
 }

--- a/beta/src/content/console-issue.md
+++ b/beta/src/content/console-issue.md
@@ -1,0 +1,17 @@
+# Test {/*test*/}
+
+<Sandpack>
+
+```js
+import { useEffect } from "react";
+        
+export default function App() {
+  useEffect(() => {
+    console.log("fire")
+  }, [])
+  
+  return <h1>Hello World</h1>
+}
+```
+
+</Sandpack>


### PR DESCRIPTION
It addresses the #5071 issue, where console logs don't print after a syntax error.

**What was happening?** The `SandpackConsole` component, which listens to the logs messages, has been conditionally rendered, and once it was unmounted after the syntax error, it takes a new render to start listening to the messages again. 

So, I passed down the visibility control to the component render, which will maintain the logs listeners.